### PR TITLE
global: add the unicode-string-literal dependency

### DIFF
--- a/{{ cookiecutter.project_shortname }}/setup.py
+++ b/{{ cookiecutter.project_shortname }}/setup.py
@@ -52,6 +52,9 @@ tests_require = [
 extras_require = {
     'docs': docs_require,
     'tests': tests_require,
+    'tests:python_version=="2.7"': [
+        'unicode-string-literal~=1.0,>=1.1',
+    ],
 }
 
 extras_require['all'] = []


### PR DESCRIPTION
Prevents some errors while dealing with Unicode by adding the
``unicode-string-literal`` dependency, which adds an extra Flake8
check for Unicode-unsafe constructs.