### PR TITLE
setup: fix install_requires keyword argument

### DIFF
--- a/{{ cookiecutter.project_shortname }}/setup.py
+++ b/{{ cookiecutter.project_shortname }}/setup.py
@@ -80,7 +80,7 @@ setup(
     description=__doc__,
     long_description=readme,
     setup_requires=setup_requires,
-    install_require=install_requires,
+    install_requires=install_requires,
     tests_require=tests_require,
     extras_require=extras_require,
     classifiers=[


### PR DESCRIPTION
Found out about this bug while bootstrapping https://github.com/inspirehep/inspire-disambiguation.