### PR TITLE
git: ignore pytest cache

### DIFF
--- a/{{ cookiecutter.project_shortname }}/.gitignore
+++ b/{{ cookiecutter.project_shortname }}/.gitignore
@@ -68,6 +68,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo


### PR DESCRIPTION
Found out about this bug while running the tests for https://github.com/inspirehep/inspire-disambiguation.